### PR TITLE
Release alluxio-enterprise 2.2.0-1.8.0 (automated commit)



### DIFF
--- a/repo/packages/A/alluxio-enterprise/100/config.json
+++ b/repo/packages/A/alluxio-enterprise/100/config.json
@@ -1,0 +1,570 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "Alluxio Enterprise Edition DC/OS service configuration properties.",
+      "properties": {
+        "name": {
+          "description": "Name of the service instance. If deploying multiple Alluxio clusters, each instance must have a unique service name.",
+          "type": "string",
+          "default": "alluxio-enterprise"
+        },
+        "alluxio-distribution": {
+          "description": "Pre-built distribution version.",
+          "type": "string",
+          "default": "all"
+        },
+        "license": {
+          "description": "Base64 encoded  Alluxio Enterprise license.",
+          "type": "string"
+        },
+        "log-level": {
+          "description": "Log level for Alluxio console logger.",
+          "type": "string",
+          "default": "INFO"
+        },
+        "master-count": {
+          "description": "The number of Alluxio masters. If you plan to have more than one master, enable zookeeper to make Alluxio work in fault tolerant mode.",
+          "type": "integer",
+          "default": 1
+        },
+        "mesos_api_version": {
+          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+          "type": "string",
+          "default": "V1"
+        },
+        "service-account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": ""
+        },
+        "service-account-secret": {
+          "description": "Path of the Secret Store credential to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "ufs-address": {
+          "description": "The root under storage address (format: <scheme>://<path>/<folder>).",
+          "type": "string"
+        },
+        "user": {
+          "description": "The user that runs the Alluxio servers and owns the Mesos sandbox.",
+          "type": "string",
+          "default": "root"
+        },
+        "worker-count": {
+          "description": "The number of Alluxio workers. Each worker has a co-located job worker used for asynchronous operations.",
+          "type": "integer",
+          "default": 1
+        },
+        "deploy-master-format": {
+          "description": "Whether to format the Alluxio Master on deployment.",
+          "type": "boolean",
+          "default": true
+        },
+        "deploy-workers": {
+          "description": "Whether to deploy Alluxio workers. If set to 'false', Alluxio workers can be started using the plan 'deploy-workers'.",
+          "type": "boolean",
+          "default": true
+        },
+        "download-url": {
+          "description": "In air-gapped environments, specify the URL to download the Alluxio tarball from.",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "required": [
+        "license",
+        "ufs-address",
+        "user"
+      ]
+    },
+    "master": {
+      "description": "Alluxio master configuration properties.",
+      "type": "object",
+      "properties": {
+        "journal-folder": {
+          "description": "The path to store master journal logs. Default value is ${MESOS_SANDBOX}/alluxio-data if left empty. If fault tolerant mode is enabled, this should point to a location in a shared storage system.",
+          "type": "string",
+          "default": ""
+        },
+        "cpus": {
+          "description": "The number of CPU shares allocated to the Alluxio master container.",
+          "type": "number",
+          "default": 2
+        },
+        "mem": {
+          "description": "The amount of memory (in MB) allocated to the Alluxio master container.",
+          "type": "integer",
+          "default": 4096
+        },
+        "disk": {
+          "description": "Alluxio master persistent disk requirements (in MB).",
+          "type": "integer",
+          "default": 2048
+        },
+        "disk-type": {
+          "description": "Disk type to be used for storing Alluxio master data: [ROOT, MOUNT].",
+          "type": "string",
+          "default": "ROOT"
+        },
+        "placement": {
+          "description": "Marathon-style placement constraint controlling node placement for Alluxio masters.",
+          "type": "string",
+          "default": "hostname:UNIQUE"
+        },
+        "job-cpus": {
+          "description": "The number of CPU shares allocated to the Alluxio job worker container.",
+          "type": "number",
+          "default": 1
+        },
+        "job-mem": {
+          "description": "The amount of memory (in MB) allocated to the Alluxio job worker container.",
+          "type": "integer",
+          "default": 1024
+        },
+        "job-disk": {
+          "description": "Alluxio job worker persistent disk requirements (in MB).",
+          "type": "integer",
+          "default": 2048
+        },
+        "job-disk-type": {
+          "description": "Disk type to be used for storing Alluxio job worker data: [ROOT, MOUNT].",
+          "type": "string",
+          "default": "ROOT"
+        },
+        "job-placement": {
+          "description": "Marathon-style placement constraint controlling node placement for Alluxio job workers.",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "job-cpus",
+        "job-mem",
+        "job-disk"
+      ]
+    },
+    "worker": {
+      "description": "Alluxio worker configuration properties.",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "The number of CPU shares allocated to the Alluxio worker container.",
+          "type": "number",
+          "default": 1
+        },
+        "mem": {
+          "description": "The amount of memory (in MB) allocated to the Alluxio worker container.",
+          "type": "integer",
+          "default": 4096
+        },
+        "mem-tier-enabled": {
+          "description": "Whether storage tier on memory is enabled.",
+          "type": "boolean",
+          "default": true
+        },
+        "mem-ramdisk": {
+          "description": "The amount of memory (in MB) allocated to the worker ramdisk for storing blocks.",
+          "type": "integer",
+          "default": 3072
+        },
+        "disk": {
+          "description": "Alluxio worker persistent disk requirements (in MB).",
+          "type": "integer",
+          "default": 2048
+        },
+        "disk-type": {
+          "description": "Disk type to be used for storing Alluxio worker data: [ROOT, MOUNT].",
+          "type": "string",
+          "default": "ROOT"
+        },
+        "disk-tier-1-enabled": {
+          "description": "Whether storage tier 1 is enabled.",
+          "type": "boolean",
+          "default": false
+        },
+        "disk-tier-1-size": {
+          "description": "Disk size for storage tier 1(in MB).",
+          "type": "integer",
+          "default": 2048
+        },
+        "disk-tier-1-type": {
+          "description": "Disk type for storage tier 1: [ROOT, MOUNT].",
+          "type": "string",
+          "default": "ROOT"
+        },
+        "disk-tier-1-alias": {
+          "description": "Name for storage tier 1: [SSD, HDD].",
+          "type": "string",
+          "default": "SSD"
+        },
+        "disk-tier-2-enabled": {
+          "description": "Whether storage tier 2 is enabled.",
+          "type": "boolean",
+          "default": false
+        },
+        "disk-tier-2-size": {
+          "description": "Disk size for storage tier 2(in MB). Set it to 0 if this tier is not used.",
+          "type": "integer",
+          "default": 2048
+        },
+        "disk-tier-2-type": {
+          "description": "Disk type for storage tier 2: [ROOT, MOUNT].",
+          "type": "string",
+          "default": "MOUNT"
+        },
+        "disk-tier-2-alias": {
+          "description": "Name for storage tier 2: [SSD, HDD].",
+          "type": "string",
+          "default": "HDD"
+        },
+        "placement": {
+          "description": "Marathon-style placement constraint controlling node placement for Alluxio workers.",
+          "type": "string",
+          "default": "hostname:UNIQUE"
+        },
+        "job-cpus": {
+          "description": "The number of CPU shares allocated to the Alluxio job master container.",
+          "type": "number",
+          "default": 1
+        },
+        "job-mem": {
+          "description": "The amount of memory (in MB) allocated to the Alluxio job master container.",
+          "type": "integer",
+          "default": 1024
+        },
+        "job-disk": {
+          "description": "Alluxio job master persistent disk requirements (in MB).",
+          "type": "integer",
+          "default": 2048
+        },
+        "job-disk-type": {
+          "description": "Disk type to be used for storing Alluxio job master data: [ROOT, MOUNT].",
+          "type": "string",
+          "default": "ROOT"
+        },
+        "job-placement": {
+          "description": "Marathon-style placement constraint controlling node placement for Alluxio job masters.",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "job-cpus",
+        "job-mem",
+        "job-disk"
+      ]
+    },
+    "security": {
+      "type": "object",
+      "description": "Alluxio security configuration properties.",
+      "properties": {
+        "authentication-type": {
+          "description": "Authentication type: [NOSASL, SIMPLE, KERBEROS].",
+          "type": "string",
+          "default": "NOSASL"
+        },
+        "authorization-permission-enabled": {
+          "description": "Whether to enable data path authorization.",
+          "type": "boolean",
+          "default": false
+        },
+        "keytab-secret": {
+          "description": "Path to base64 encoded keytab secret (format: <service.name>/__dcos_base64__<keytab>). This keytab is used by Alluxio servers.",
+          "type": "string",
+          "default": ""
+        },
+        "kerberos-primary": {
+          "description": "The Kerberos primary used by Alluxio servers. The full principal will be <security.kerberos-primary>/<security.kerberos-instance>@<security.kerberos-realm>",
+          "type": "string",
+          "default": "hdfs"
+        },
+        "kerberos-instance": {
+          "description": "The cluster-wide unified instance name shared by all Alluxio servers.",
+          "type": "string",
+          "default": "alluxio"
+        },
+        "kerberos-realm": {
+          "description": "The Kerberos realm used to render the principal of Alluxio servers.",
+          "type": "string",
+          "default": "ALLUXIO.COM"
+        },
+        "krb5-secret": {
+          "description": "Path to krb5.conf secret (format: <service-name>/<krb5-conf>). This path is used by the Alluxio servers to connect to your KDC.",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "docker": {
+      "type": "object",
+      "description": "Configuration properties for building docker images.",
+      "properties": {
+        "publish-url": {
+          "description": "Docker registry to host any built images (format: test-registry.marathon.mesos:5001)",
+          "type": "string",
+          "default": ""
+        },
+        "alluxio-client-base": {
+          "description": "Base docker image to build on",
+          "type": "string",
+          "default": "openjdk:8-jre"
+        },
+        "spark-client-base": {
+          "description": "Base docker image to build on",
+          "type": "string",
+          "default": "mesosphere/spark:1.0.6-2.0.2-hadoop-2.6"
+        },
+        "spark-dist-home": {
+          "description": "Spark distribution home in the base docker image",
+          "type": "string",
+          "default": "/opt/spark/dist"
+        }
+      }
+    },
+    "advanced": {
+      "description": "Advanced configuration properties.",
+      "type": "object",
+      "properties": {
+        "extra-java-opts": {
+          "description": "Java VM options for both Alluxio servers and shell configuration (format: '-Dalluxio.property1=common1 -Dalluxio.property2=common2'; delimiter: ' ' (space)).",
+          "type": "string",
+          "default": ""
+        },
+        "extra-client-properties": {
+          "description": "Properties added to client-side alluxio-site.properties (format: 'alluxio.user.file.writetype.default=CACHE_THROUGH alluxio.user.file.readtype.default=NO_CACHE'; delimiter: ' ' (space)).",
+          "type": "string",
+          "default": ""
+        },
+        "extra-user-java-opts": {
+          "description": "Java VM options for Alluxio shell configuration (format: '-Dalluxio.property1=shell1 -Dalluxio.property2=shell2'; delimiter: ' ' (space)).",
+          "type": "string",
+          "default": ""
+        },
+        "extra-master-java-opts": {
+          "description": "Java VM options for Alluxio master configuration (format: '-Dalluxio.property1=master1 -Dalluxio.property2=master2'; delimiter: ' ' (space)).",
+          "type": "string",
+          "default": ""
+        },
+        "extra-worker-java-opts": {
+          "description": "Java VM options for Alluxio worker configuration (format: '-Dalluxio.property1=worker1 -Dalluxio.property2=worker2'; delimiter: ' ' (space)).",
+          "type": "string",
+          "default": ""
+        },
+        "extra-job-master-java-opts": {
+          "description": "Java VM options for Alluxio job-aster configuration (format: '-Dalluxio.property1=jmaster1 -Dalluxio.property2=jmaster2'; delimiter: ' ' (space)).",
+          "type": "string",
+          "default": ""
+        },
+        "extra-job-worker-java-opts": {
+          "description": "Java VM options for Alluxio job-worker configuration (format: '-Dalluxio.property1=jworker1 -Dalluxio.property2=jworker2'; delimiter: ' ' (space)).",
+          "type": "string",
+          "default": ""
+        },
+        "extra-env": {
+          "description": "Environment properties added to client-side alluxio-env.sh (format: 'ALLUXIO_ENV_VAR1=value1 ALLUXIO_ENV_VAR2=value2'; delimiter: ' ' (space))",
+          "type": "string",
+          "default": ""
+        },
+        "extra-keytab-secret-1": {
+          "description": "Extra path to base64 encoded keytab secret (format: <service.name>/__dcos_base64__<keytab>). Secret is downloaded to ${MESOS_SANDBOX}/extra-keytab-1.keytab.",
+          "type": "string",
+          "default": ""
+        },
+        "extra-keytab-secret-2": {
+          "description": "Extra path to base64 encoded keytab secret (format: <service.name>/__dcos_base64__<keytab>). Secret is downloaded to ${MESOS_SANDBOX}/extra-keytab-2.keytab.",
+          "type": "string",
+          "default": ""
+        },
+        "extra-keytab-secret-3": {
+          "description": "Extra path to base64 encoded keytab secret (format: <service.name>/__dcos_base64__<keytab>). Secret is downloaded to ${MESOS_SANDBOX}/extra-keytab-3.keytab.",
+          "type": "string",
+          "default": ""
+        },
+        "extra-keytab-secret-4": {
+          "description": "Extra path to base64 encoded keytab secret (format: <service.name>/__dcos_base64__<keytab>). Secret is downloaded to ${MESOS_SANDBOX}/extra-keytab-4.keytab.",
+          "type": "string",
+          "default": ""
+        },
+        "extra-keytab-secret-5": {
+          "description": "Extra path to base64 encoded keytab secret (format: <service.name>/__dcos_base64__<keytab>). Secret is downloaded to ${MESOS_SANDBOX}/extra-keytab-5.keytab.",
+          "type": "string",
+          "default": ""
+        },
+        "custom-resources": {
+          "description": "Download custom resources into the sandbox (format: '<destination-name-1>;<source-url-1> <destination-name-2>;<source-url-2>'). The path is downloaded to ${MESOS_SANDBOX}/<destination-name>. Note: a. All destinations with the suffix '.keytab' will have permissions 640, b. The Alluxio server keytab (if specified) must be named 'alluxio.keytab', c. The Kerberos configuration file (if specified) must be named 'krb5.conf'.",
+          "type": "string",
+          "default": ""
+        },
+        "worker-A-count": {
+          "description": "The number of Alluxio workers in set A. This can be used to launch workers with different placement constraints.",
+          "type": "integer",
+          "default": 1
+        },
+        "deploy-workers-A": {
+          "description": "Whether to deploy Alluxio worker set A. If set to 'false', Alluxio workers can be started using the plan 'deploy-workers-A'.",
+          "type": "boolean",
+          "default": false
+        },
+        "worker-A-placement": {
+          "description": "Marathon-style placement constraint controlling node placement for Alluxio worker set A",
+          "type": "string",
+          "default": "hostname:UNIQUE"
+        }
+      }
+    },
+    "network": {
+      "description": "Port configuration for Alluxio servers.",
+      "type": "object",
+      "properties": {
+        "master-port": {
+          "description": "The port that Alluxio master node runs on.",
+          "type": "number",
+          "default": 19998
+        },
+        "master-web-port": {
+          "description": "The port Alluxio web UI runs on.",
+          "type": "number",
+          "default": 19999
+        },
+        "worker-port": {
+          "description": "The port Alluxio's worker node runs on.",
+          "type": "number",
+          "default": 29998
+        },
+        "worker-data-port": {
+          "description": "The port Alluxio's worker's data server runs on.",
+          "type": "number",
+          "default": 29999
+        },
+        "worker-web-port": {
+          "description": "The port Alluxio worker's web UI runs on.",
+          "type": "number",
+          "default": 30000
+        },
+        "worker-secure-port": {
+          "description": "The port Alluxio worker's secure RPC runs on.",
+          "type": "number",
+          "default": 29997
+        },
+        "job-master-port": {
+          "description": "The RPC port that Alluxio job-master node runs on.",
+          "type": "number",
+          "default": 20001
+        },
+        "job-master-web-port": {
+          "description": "The port Alluxio job master web server runs on.",
+          "type": "number",
+          "default": 20002
+        },
+        "job-worker-port": {
+          "description": "The port Alluxio's job-worker node runs on.",
+          "type": "number",
+          "default": 30001
+        },
+        "job-worker-data-port": {
+          "description": "The port Alluxio job-worker's data server runs on.",
+          "type": "number",
+          "default": 30002
+        },
+        "job-worker-web-port": {
+          "description": "The port Alluxio job worker's web server runs on.",
+          "type": "number",
+          "default": 30003
+        },
+        "job-worker-secure-port": {
+          "description": "The port Alluxio job-worker's secure RPC runs on.",
+          "type": "number",
+          "default": 30004
+        },
+        "proxy-web-port": {
+          "description": "The port Alluxio proxy server runs on.",
+          "type": "number",
+          "default": 19997
+        }
+      }
+    },
+    "hdfs": {
+      "type": "object",
+      "description": "Configuration properties required to setup HDFS UFS.",
+      "properties": {
+        "endpoint": {
+          "description": "URL to download HDFS configuration (hdfs-site.xml, core-site.xml) from (including http header).",
+          "type": "string",
+          "default": ""
+        },
+        "root-version": {
+          "description": "The version of HDFS specified for the root UFS (supported: [1.0, 1.2, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, cdh5.6, cdh5.8, cdh5.11, cdh5.12, hdp2.4, hdp2.5, mapr5.2]).",
+          "type": "string",
+          "default": ""
+        },
+        "journal-version": {
+          "description": "The version of HDFS specified for the journal.",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "s3a": {
+      "type": "object",
+      "description": "Configuration properties required to mount an Amazon S3 bucket.",
+      "properties": {
+        "aws-access-key": {
+          "description": "S3 Access key",
+          "type": "string",
+          "default": ""
+        },
+        "aws-secret-key": {
+          "description": "S3 Secret key",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "virtual-network": {
+      "type": "object",
+      "description": "Configuration properties to launch in a virtual network",
+      "properties": {
+        "enabled": {
+          "description": "Enable virtual networking",
+          "type": "boolean",
+          "default": false
+        },
+        "name": {
+          "description": "The name of the virtual network to join",
+          "type": "string",
+          "default": "dcos"
+        },
+        "plugin-labels": {
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "zookeeper": {
+      "type": "object",
+      "description": "Configuration properties required to setup fault tolerant Alluxio.",
+      "properties": {
+        "enabled": {
+          "description": "If true, setup master fault tolerant mode using ZooKeeper.",
+          "type": "boolean",
+          "default": false
+        },
+        "address": {
+          "description": "Address of ZooKeeper.",
+          "type": "string",
+          "default": ""
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/A/alluxio-enterprise/100/marathon.json.mustache
+++ b/repo/packages/A/alluxio-enterprise/100/marathon.json.mustache
@@ -1,0 +1,188 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 2048,
+  "instances": 1,
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*_jce_policy/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && ./alluxio-enterprise-scheduler/bin/alluxio-enterprise ./alluxio-enterprise-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http",
+    "MARATHON_SINGLE_INSTANCE_APP": "true"
+  },
+  {{#service.service-account-secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service-account-secret}}"
+    }
+  },
+  {{/service.service-account-secret}}
+  "env": {
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1533057184264",
+    "PACKAGE_BUILD_TIME_STR": "Tue Jul 31 2018 17:13:04 +0000",
+    "PACKAGE_NAME": "alluxio-enterprise",
+    "PACKAGE_VERSION": "2.2.0-1.8.0",
+
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "JAVA_URI": "{{resource.assets.uris.java-tar-gz}}",
+    "JRE_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+    "TASKCFG_ALL_ALLUXIO_AGENT_DARWIN_386_URL": "{{resource.assets.uris.alluxio-agent-darwin_386}}",
+    "TASKCFG_ALL_ALLUXIO_AGENT_DARWIN_AMD64_URL": "{{resource.assets.uris.alluxio-agent-darwin_amd64}}",
+    "TASKCFG_ALL_ALLUXIO_AGENT_LINUX_386_URL": "{{resource.assets.uris.alluxio-agent-linux_386}}",
+    "TASKCFG_ALL_ALLUXIO_AGENT_LINUX_AMD64_URL": "{{resource.assets.uris.alluxio-agent-linux_amd64}}",
+    "TASKCFG_ALL_CUSTOM_DOWNLOAD_URL": "{{service.download-url}}",
+
+    {{#service.service-account-secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    {{/service.service-account-secret}}
+
+    "SERVICE_PRINCIPAL": "{{service.service-account}}",
+    "SERVICE_USER": "{{service.user}}",
+    "TASKCFG_ALL_ALLUXIO_DISTRIBUTION": "{{service.alluxio-distribution}}",
+    "TASKCFG_ALL_ALLUXIO_LICENSE": "{{service.license}}",
+    "TASKCFG_ALL_ALLUXIO_VERSION": "1.8.0",
+    "TASKCFG_ALL_LOG_LEVEL": "{{service.log-level}}",
+    "TASKCFG_ALL_SERVICE_NAME": "{{service.name}}",
+
+    "TASKCFG_ALL_ALLUXIO_DOMAIN_SOCKET_LOCATION": "/tmp/domain",
+    "TASKCFG_ALL_ALLUXIO_EXTRA_CLIENT_PROPERTIES": "{{advanced.extra-client-properties}}",
+    "TASKCFG_ALL_ALLUXIO_EXTRA_JAVA_OPTS": "{{advanced.extra-java-opts}}",
+    "TASKCFG_ALL_ALLUXIO_EXTRA_USER_JAVA_OPTS": "{{advanced.extra-user-java-opts}}",
+    "TASKCFG_ALL_ALLUXIO_EXTRA_MASTER_JAVA_OPTS": "{{advanced.extra-master-java-opts}}",
+    "TASKCFG_ALL_ALLUXIO_EXTRA_WORKER_JAVA_OPTS": "{{advanced.extra-worker-java-opts}}",
+    "TASKCFG_ALL_ALLUXIO_EXTRA_JOB_MASTER_JAVA_OPTS": "{{advanced.extra-job-master-java-opts}}",
+    "TASKCFG_ALL_ALLUXIO_EXTRA_JOB_WORKER_JAVA_OPTS": "{{advanced.extra-job-worker-java-opts}}",
+    "TASKCFG_ALL_ALLUXIO_EXTRA_ENV": "{{advanced.extra-env}}",
+    "TASKCFG_ALL_ALLUXIO_TMPFS_LOCATION": "/dev/shm",
+    "TASKCFG_ALL_DOWNLOAD_CUSTOM_RESOURCES": "{{advanced.custom-resources}}",
+    "EXTRA_KEYTAB_SECRET_1": "{{advanced.extra-keytab-secret-1}}",
+    "EXTRA_KEYTAB_SECRET_2": "{{advanced.extra-keytab-secret-2}}",
+    "EXTRA_KEYTAB_SECRET_3": "{{advanced.extra-keytab-secret-3}}",
+    "EXTRA_KEYTAB_SECRET_4": "{{advanced.extra-keytab-secret-4}}",
+    "EXTRA_KEYTAB_SECRET_5": "{{advanced.extra-keytab-secret-5}}",
+
+    "DEPLOY_MASTER_FORMAT": "{{service.deploy-master-format}}",
+    "DEPLOY_WORKERS": "{{service.deploy-workers}}",
+    "DEPLOY_WORKERS_A": "{{advanced.deploy-workers-A}}",
+    "MASTER_COUNT": "{{service.master-count}}",
+    "WORKER_COUNT": "{{service.worker-count}}",
+    "WORKER_A_COUNT": "{{advanced.worker-A-count}}",
+    "PROXY_COUNT": "1",
+
+    {{#virtual-network.enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{virtual-network.name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{virtual-network.plugin-labels}}",
+    {{/virtual-network.enabled}}
+
+    "SECURITY_KEYTAB_SECRET": "{{security.keytab-secret}}",
+    "SECURITY_KRB5_SECRET": "{{security.krb5-secret}}",
+    "TASKCFG_ALL_SECURITY_AUTHENTICATION_TYPE": "{{security.authentication-type}}",
+    "TASKCFG_ALL_SECURITY_AUTHORIZATION_PERMISSION_ENABLED": "{{security.authorization-permission-enabled}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_PRIMARY": "{{security.kerberos-primary}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_INSTANCE": "{{security.kerberos-instance}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_REALM": "{{security.kerberos-realm}}",
+
+    "TASKCFG_ALL_DOCKER_PUBLISH_URL": "{{docker.publish-url}}",
+    "TASKCFG_ALL_DOCKER_ALLUXIO_CLIENT_BASE": "{{docker.alluxio-client-base}}",
+    "TASKCFG_ALL_DOCKER_SPARK_CLIENT_BASE": "{{docker.spark-client-base}}",
+    "TASKCFG_ALL_DOCKER_SPARK_DIST_HOME": "{{docker.spark-dist-home}}",
+
+    "TASKCFG_ALL_UFS_ADDRESS": "{{service.ufs-address}}",
+
+    "TASKCFG_ALL_AWS_ACCESS_KEY": "{{s3a.aws-access-key}}",
+    "TASKCFG_ALL_AWS_SECRET_KEY": "{{s3a.aws-secret-key}}",
+
+    "TASKCFG_ALL_ZK_ENABLED": "{{zookeeper.enabled}}",
+    "TASKCFG_ALL_ZK_ADDRESS": "{{zookeeper.address}}",
+
+    "HDFS_ENDPOINT": "{{hdfs.endpoint}}",
+    "TASKCFG_ALL_ROOT_HDFS_VERSION": "{{hdfs.root-version}}",
+    "TASKCFG_ALL_JOURNAL_HDFS_VERSION": "{{hdfs.journal-version}}",
+
+    "MASTER_CPUS": "{{master.cpus}}",
+    "MASTER_MEM": "{{master.mem}}",
+    "MASTER_DISK": "{{master.disk}}",
+    "MASTER_DISK_TYPE": "{{master.disk-type}}",
+    "MASTER_PLACEMENT": "{{master.placement}}",
+    "TASKCFG_ALL_MASTER_JOURNAL_FOLDER": "{{master.journal-folder}}",
+
+    "WORKER_CPUS": "{{worker.cpus}}",
+    "WORKER_MEM": "{{worker.mem}}",
+    "TASKCFG_ALL_WORKER_MEM_RAMDISK": "{{worker.mem-ramdisk}}",
+    "TASKCFG_ALL_WORKER_MEM_TIER_ENABLED": "{{worker.mem-tier-enabled}}",
+    "WORKER_DISK": "{{worker.disk}}",
+    "WORKER_DISK_TYPE": "{{worker.disk-type}}",
+    "WORKER_DISK_TIER_1_TYPE": "{{worker.disk-tier-1-type}}",
+    "TASKCFG_ALL_WORKER_DISK_TIER_1_ENABLED": "{{worker.disk-tier-1-enabled}}",
+    "TASKCFG_ALL_WORKER_DISK_TIER_1_SIZE": "{{worker.disk-tier-1-size}}",
+    "TASKCFG_ALL_WORKER_DISK_TIER_1_ALIAS": "{{worker.disk-tier-1-alias}}",
+    "WORKER_DISK_TIER_2_TYPE": "{{worker.disk-tier-2-type}}",
+    "TASKCFG_ALL_WORKER_DISK_TIER_2_ENABLED": "{{worker.disk-tier-2-enabled}}",
+    "TASKCFG_ALL_WORKER_DISK_TIER_2_SIZE": "{{worker.disk-tier-2-size}}",
+    "TASKCFG_ALL_WORKER_DISK_TIER_2_ALIAS": "{{worker.disk-tier-2-alias}}",
+    "WORKER_PLACEMENT": "{{worker.placement}}",
+    "WORKER_A_PLACEMENT": "{{advanced.worker-A-placement}}",
+
+    "JOB_MASTER_CPUS": "{{master.job-cpus}}",
+    "JOB_MASTER_MEM": "{{master.job-mem}}",
+    "JOB_MASTER_DISK": "{{master.job-disk}}",
+    "JOB_MASTER_DISK_TYPE": "{{master.job-disk-type}}",
+    "JOB_MASTER_PLACEMENT": "{{master.job-placement}}",
+    "JOB_WORKER_CPUS": "{{worker.job-cpus}}",
+    "JOB_WORKER_MEM": "{{worker.job-mem}}",
+    "JOB_WORKER_DISK": "{{worker.job-disk}}",
+    "JOB_WORKER_DISK_TYPE": "{{worker.job-disk-type}}",
+    "JOB_WORKER_PLACEMENT": "{{worker.job-placement}}",
+    "DOCKER_CPUS": "1",
+    "DOCKER_MEM": "4096",
+    "DOCKER_DISK": "4096",
+    "DOCKER_DISK_TYPE": "ROOT",
+    "DOCKER_PLACEMENT": "",
+    "PROXY_PLACEMENT": "",
+    "PROXY_CPUS": "1",
+    "PROXY_MEM": "1024",
+    "PROXY_DISK": "1024",
+    "PROXY_DISK_TYPE": "ROOT",
+
+    "TASKCFG_ALL_ALLUXIO_MASTER_PORT": "{{network.master-port}}",
+    "TASKCFG_ALL_ALLUXIO_MASTER_WEB_PORT": "{{network.master-web-port}}",
+    "TASKCFG_ALL_ALLUXIO_WORKER_PORT": "{{network.worker-port}}",
+    "TASKCFG_ALL_ALLUXIO_WORKER_DATA_PORT": "{{network.worker-data-port}}",
+    "TASKCFG_ALL_ALLUXIO_WORKER_SECURE_RPC_PORT": "{{network.worker-secure-port}}",
+    "TASKCFG_ALL_ALLUXIO_WORKER_WEB_PORT": "{{network.worker-web-port}}",
+    "TASKCFG_ALL_ALLUXIO_JOB_MASTER_RPC_PORT": "{{network.job-master-port}}",
+    "TASKCFG_ALL_ALLUXIO_JOB_MASTER_WEB_PORT": "{{network.job-master-web-port}}",
+    "TASKCFG_ALL_ALLUXIO_JOB_WORKER_RPC_PORT": "{{network.job-worker-port}}",
+    "TASKCFG_ALL_ALLUXIO_JOB_WORKER_DATA_PORT": "{{network.job-worker-data-port}}",
+    "TASKCFG_ALL_ALLUXIO_JOB_WORKER_WEB_PORT": "{{network.job-worker-web-port}}",
+    "TASKCFG_ALL_ALLUXIO_JOB_WORKER_SECURE_RPC_PORT": "{{network.job-worker-secure-port}}",
+    "TASKCFG_ALL_ALLUXIO_PROXY_WEB_PORT": "{{network.proxy-web-port}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.java-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/A/alluxio-enterprise/100/package.json
+++ b/repo/packages/A/alluxio-enterprise/100/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "4.0",
+  "upgradesFrom": [],
+  "downgradesTo": [],
+  "name": "alluxio-enterprise",
+  "version": "2.2.0-1.8.0",
+  "maintainer": "info@alluxio.com",
+  "description": "Alluxio, formerly Tachyon, is the world's first system that unifies disparate storage systems at memory speed. With Alluxio, enterprises can manage data efficiently, accelerate business analytics, and ease the adoption of hybrid cloud. \n\n Alluxio Enterprise Edition delivers operational benefits of a stable, high performance system with enterprise features and support for critical deployments. Please refer to https://alluxio.com/docs/enterprise/1.7/en/Alluxio-on-DCOS.html for a detailed operation guide. \n\n Release Notes: \n - Upgrade to version 1.7.1 of Alluxio \n - Support downloading multiple keytabs from Secret Store",
+  "selected": false,
+  "framework": true,
+  "tags": [
+    "enterprise",
+    "alluxio"
+  ],
+  "minDcosReleaseVersion": "1.10",
+  "preInstallNotes": "Visit https://alluxio.com/products to obtain a license for Alluxio Enterprise Edition.\n\nDefault configuration requires 2 agent nodes each with: CPU: 3 | Memory: 5GB | Disk: 4GB\n\nMore specifically, each instance type requires:\n\nMaster: 1 instance | 2 CPU | 4096 MB MEM | 1 2048 MB Disk\n\nJob master: 1 instance | 1 CPU | 1024 MB MEM | 1 2048 MB Disk\n\nWorker: 1 instance | 2 CPU | 4096 MB MEM | 1 2048 MB Disk \n\nJob worker: 1 instance | 1 CPU | 1024 MB MEM | 1 2048 MB Disk \n\nVersion 2.0.0-1.6.0 contains breaking changes from previous releases. Upgrading from previous versions is not supported.",
+  "postInstallNotes": "DC/OS Alluxio is being installed!\n\n\tDocumentation: https://alluxio.com/docs/enterprise/1.7/en/Alluxio-on-DCOS.html \n\tIssues: info@aluxio.com",
+  "postUninstallNotes": "DC/OS Alluxio has been uninstalled. \n\n Visit https://alluxio.com/docs/enterprise/1.7/en/Alluxio-on-DCOS.html to troubleshoot any issues."
+}

--- a/repo/packages/A/alluxio-enterprise/100/resource.json
+++ b/repo/packages/A/alluxio-enterprise/100/resource.json
@@ -1,0 +1,61 @@
+{
+  "assets": {
+    "uris": {
+      "alluxio-agent-darwin_386": "https://alluxio-dcos-release.s3.amazonaws.com/agent/v1.5.0/darwin_386/alluxio-dcos",
+      "alluxio-agent-darwin_amd64": "https://alluxio-dcos-release.s3.amazonaws.com/agent/v1.5.0/darwin_amd64/alluxio-dcos",
+      "alluxio-agent-linux_386": "https://alluxio-dcos-release.s3.amazonaws.com/agent/v1.5.0/linux_386/alluxio-dcos",
+      "alluxio-agent-linux_amd64": "https://alluxio-dcos-release.s3.amazonaws.com/agent/v1.5.0/linux_amd64/alluxio-dcos",
+      "bootstrap-zip": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.2.0-1.8.0/bootstrap.zip",
+      "executor-zip": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.2.0-1.8.0/executor.zip",
+      "java-tar-gz": "https://alluxio-dcos-release.s3.amazonaws.com/jdk/jdk1.8.0_144_jce_policy.tar.gz",
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
+      "scheduler-zip": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.2.0-1.8.0/alluxio-enterprise-scheduler.zip"
+    }
+  },
+  "images": {
+    "icon-small": "https://alluxio-dcos-release.s3.amazonaws.com/icons/v1.0.0/alluxio_logo_small.png?raw=true",
+    "icon-medium": "https://alluxio-dcos-release.s3.amazonaws.com/icons/v1.0.0/alluxio_logo_medium.png?raw=true",
+    "icon-large": "https://alluxio-dcos-release.s3.amazonaws.com/icons/v1.0.0/alluxio_logo_large.png?raw=true"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "824feb0df24dcdc92ef18781b13da26190f87fd94533b51959dccf08311a0e0a"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.2.0-1.8.0/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "dd6d1a9b395dcb15239dad1de8d85c231a8624d0501402cc4c7d246b986f5387"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.2.0-1.8.0/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "aec3e50813439b2478bf5bdb6a4dc54e6d2e9bdd607c59de82f9a11a5f4bd450"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.2.0-1.8.0/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release alluxio-enterprise 2.2.0-1.8.0 (automated commit)

Description:
Alluxio Enterprise Edition

Source URL: https://alluxio-dcos-dev.s3.amazonaws.com/autodelete7d/alluxio-enterprise/20180731-101301-vKBa4OC06UfUOx9Z/stub-universe-alluxio-enterprise.json

Changes between revisions 2 => 100:
0 files added: []
0 files removed: []
4 files changed:

```
--- 2/config.json
+++ 100/config.json
@@ -11,9 +11,9 @@
           "default": "alluxio-enterprise"
         },
         "alluxio-distribution": {
-          "description": "Pre-built distribution version: [cdh-5.8, hadoop-1.2, hadoop-2.7, hdp-2.5, mapr-5.2].",
-          "type": "string",
-          "default": "hadoop-2.7"
+          "description": "Pre-built distribution version.",
+          "type": "string",
+          "default": "all"
         },
         "license": {
           "description": "Base64 encoded  Alluxio Enterprise license.",
@@ -29,6 +29,11 @@
           "type": "integer",
           "default": 1
         },
+        "mesos_api_version": {
+          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+          "type": "string",
+          "default": "V1"
+        },
         "service-account": {
           "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
           "type": "string",
@@ -52,6 +57,21 @@
           "description": "The number of Alluxio workers. Each worker has a co-located job worker used for asynchronous operations.",
           "type": "integer",
           "default": 1
+        },
+        "deploy-master-format": {
+          "description": "Whether to format the Alluxio Master on deployment.",
+          "type": "boolean",
+          "default": true
+        },
+        "deploy-workers": {
+          "description": "Whether to deploy Alluxio workers. If set to 'false', Alluxio workers can be started using the plan 'deploy-workers'.",
+          "type": "boolean",
+          "default": true
+        },
+        "download-url": {
+          "description": "In air-gapped environments, specify the URL to download the Alluxio tarball from.",
+          "type": "string",
+          "default": ""
         }
       },
       "required": [
@@ -354,10 +374,50 @@
           "type": "string",
           "default": ""
         },
+        "extra-keytab-secret-1": {
+          "description": "Extra path to base64 encoded keytab secret (format: <service.name>/__dcos_base64__<keytab>). Secret is downloaded to ${MESOS_SANDBOX}/extra-keytab-1.keytab.",
+          "type": "string",
+          "default": ""
+        },
+        "extra-keytab-secret-2": {
+          "description": "Extra path to base64 encoded keytab secret (format: <service.name>/__dcos_base64__<keytab>). Secret is downloaded to ${MESOS_SANDBOX}/extra-keytab-2.keytab.",
+          "type": "string",
+          "default": ""
+        },
+        "extra-keytab-secret-3": {
+          "description": "Extra path to base64 encoded keytab secret (format: <service.name>/__dcos_base64__<keytab>). Secret is downloaded to ${MESOS_SANDBOX}/extra-keytab-3.keytab.",
+          "type": "string",
+          "default": ""
+        },
+        "extra-keytab-secret-4": {
+          "description": "Extra path to base64 encoded keytab secret (format: <service.name>/__dcos_base64__<keytab>). Secret is downloaded to ${MESOS_SANDBOX}/extra-keytab-4.keytab.",
+          "type": "string",
+          "default": ""
+        },
+        "extra-keytab-secret-5": {
+          "description": "Extra path to base64 encoded keytab secret (format: <service.name>/__dcos_base64__<keytab>). Secret is downloaded to ${MESOS_SANDBOX}/extra-keytab-5.keytab.",
+          "type": "string",
+          "default": ""
+        },
         "custom-resources": {
-          "description": "Download custom resources into the sandbox (format: 'DST_PATH1;SOURCE_URL1 DST_PATH2;SOURCE_URL2'). The destination path is relative to the Alluxio home directory (parent of `bin` and `conf`)",
-          "type": "string",
-          "default": ""
+          "description": "Download custom resources into the sandbox (format: '<destination-name-1>;<source-url-1> <destination-name-2>;<source-url-2>'). The path is downloaded to ${MESOS_SANDBOX}/<destination-name>. Note: a. All destinations with the suffix '.keytab' will have permissions 640, b. The Alluxio server keytab (if specified) must be named 'alluxio.keytab', c. The Kerberos configuration file (if specified) must be named 'krb5.conf'.",
+          "type": "string",
+          "default": ""
+        },
+        "worker-A-count": {
+          "description": "The number of Alluxio workers in set A. This can be used to launch workers with different placement constraints.",
+          "type": "integer",
+          "default": 1
+        },
+        "deploy-workers-A": {
+          "description": "Whether to deploy Alluxio worker set A. If set to 'false', Alluxio workers can be started using the plan 'deploy-workers-A'.",
+          "type": "boolean",
+          "default": false
+        },
+        "worker-A-placement": {
+          "description": "Marathon-style placement constraint controlling node placement for Alluxio worker set A",
+          "type": "string",
+          "default": "hostname:UNIQUE"
         }
       }
     },
--- 2/marathon.json.mustache
+++ 100/marathon.json.mustache
@@ -3,7 +3,7 @@
   "cpus": 1.0,
   "mem": 2048,
   "instances": 1,
-  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && ./alluxio-enterprise-scheduler/bin/alluxio-enterprise ./alluxio-enterprise-scheduler/svc.yml",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*_jce_policy/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && ./alluxio-enterprise-scheduler/bin/alluxio-enterprise ./alluxio-enterprise-scheduler/svc.yml",
   "labels": {
     "DCOS_COMMONS_API_VERSION": "v1",
     "DCOS_COMMONS_UNINSTALL": "true",
@@ -21,20 +21,22 @@
   },
   {{/service.service-account-secret}}
   "env": {
-    "PACKAGE_BUILD_TIME_EPOCH_MS": "1509575074810",
-    "PACKAGE_BUILD_TIME_STR": "Wed Nov 01 2017 22:24:34 +0000",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1533057184264",
+    "PACKAGE_BUILD_TIME_STR": "Tue Jul 31 2018 17:13:04 +0000",
     "PACKAGE_NAME": "alluxio-enterprise",
-    "PACKAGE_VERSION": "2.0.0-1.6.0",
+    "PACKAGE_VERSION": "2.2.0-1.8.0",
 
     "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
     "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
     "JAVA_URI": "{{resource.assets.uris.java-tar-gz}}",
     "JRE_URI": "{{resource.assets.uris.jre-tar-gz}}",
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
-    "TASKCFG_ALL_ALLUXIO_AGENT_URL": "{{resource.assets.uris.alluxio-agent}}",
-    "TASKCFG_ALL_CUSTOM_DOWNLOAD_URL": "{{resource.assets.uris.custom-download-url}}",
-    "TASKCFG_ALL_CUSTOM_KEYTAB_URL": "",
-    "TASKCFG_ALL_CUSTOM_KRB5_URL": "",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+    "TASKCFG_ALL_ALLUXIO_AGENT_DARWIN_386_URL": "{{resource.assets.uris.alluxio-agent-darwin_386}}",
+    "TASKCFG_ALL_ALLUXIO_AGENT_DARWIN_AMD64_URL": "{{resource.assets.uris.alluxio-agent-darwin_amd64}}",
+    "TASKCFG_ALL_ALLUXIO_AGENT_LINUX_386_URL": "{{resource.assets.uris.alluxio-agent-linux_386}}",
+    "TASKCFG_ALL_ALLUXIO_AGENT_LINUX_AMD64_URL": "{{resource.assets.uris.alluxio-agent-linux_amd64}}",
+    "TASKCFG_ALL_CUSTOM_DOWNLOAD_URL": "{{service.download-url}}",
 
     {{#service.service-account-secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
@@ -46,7 +48,7 @@
     "SERVICE_USER": "{{service.user}}",
     "TASKCFG_ALL_ALLUXIO_DISTRIBUTION": "{{service.alluxio-distribution}}",
     "TASKCFG_ALL_ALLUXIO_LICENSE": "{{service.license}}",
-    "TASKCFG_ALL_ALLUXIO_VERSION": "1.6.0",
+    "TASKCFG_ALL_ALLUXIO_VERSION": "1.8.0",
     "TASKCFG_ALL_LOG_LEVEL": "{{service.log-level}}",
     "TASKCFG_ALL_SERVICE_NAME": "{{service.name}}",
 
@@ -61,9 +63,18 @@
     "TASKCFG_ALL_ALLUXIO_EXTRA_ENV": "{{advanced.extra-env}}",
     "TASKCFG_ALL_ALLUXIO_TMPFS_LOCATION": "/dev/shm",
     "TASKCFG_ALL_DOWNLOAD_CUSTOM_RESOURCES": "{{advanced.custom-resources}}",
+    "EXTRA_KEYTAB_SECRET_1": "{{advanced.extra-keytab-secret-1}}",
+    "EXTRA_KEYTAB_SECRET_2": "{{advanced.extra-keytab-secret-2}}",
+    "EXTRA_KEYTAB_SECRET_3": "{{advanced.extra-keytab-secret-3}}",
+    "EXTRA_KEYTAB_SECRET_4": "{{advanced.extra-keytab-secret-4}}",
+    "EXTRA_KEYTAB_SECRET_5": "{{advanced.extra-keytab-secret-5}}",
 
+    "DEPLOY_MASTER_FORMAT": "{{service.deploy-master-format}}",
+    "DEPLOY_WORKERS": "{{service.deploy-workers}}",
+    "DEPLOY_WORKERS_A": "{{advanced.deploy-workers-A}}",
     "MASTER_COUNT": "{{service.master-count}}",
     "WORKER_COUNT": "{{service.worker-count}}",
+    "WORKER_A_COUNT": "{{advanced.worker-A-count}}",
     "PROXY_COUNT": "1",
 
     {{#virtual-network.enabled}}
@@ -119,6 +130,7 @@
     "TASKCFG_ALL_WORKER_DISK_TIER_2_SIZE": "{{worker.disk-tier-2-size}}",
     "TASKCFG_ALL_WORKER_DISK_TIER_2_ALIAS": "{{worker.disk-tier-2-alias}}",
     "WORKER_PLACEMENT": "{{worker.placement}}",
+    "WORKER_A_PLACEMENT": "{{advanced.worker-A-placement}}",
 
     "JOB_MASTER_CPUS": "{{master.job-cpus}}",
     "JOB_MASTER_MEM": "{{master.job-mem}}",
--- 2/package.json
+++ 100/package.json
@@ -1,19 +1,19 @@
 {
-    "packagingVersion": "4.0",
-    "upgradesFrom": [],
-    "downgradesTo": [],
-    "name": "alluxio-enterprise",
-    "version": "2.0.0-1.6.0",
-    "maintainer": "info@alluxio.com",
-    "description": "Alluxio, formerly Tachyon, is the world's first system that unifies disparate storage systems at memory speed. With Alluxio, enterprises can manage data efficiently, accelerate business analytics, and ease the adoption of hybrid cloud. \n\n Alluxio Enterprise Edition delivers operational benefits of a stable, high performance system with enterprise features and support for critical deployments. Please refer to https://alluxio.com/docs/enterprise/1.6/en/Alluxio-on-DCOS.html for a detailed operation guide. \n\n Release Notes: \n - Upgrade to version 1.6.0 of Alluxio \n - Secured deployment enhancements \n - Alluxio Master UI access \n - Tiered Storage Support \n - HA Support \n - REST API Support",
-    "selected": false,
-    "framework": true,
-    "tags": [
-        "enterprise",
-        "alluxio"
-    ],
-    "minDcosReleaseVersion": "1.10",
-    "preInstallNotes": "Visit https://alluxio.com/products to obtain a license for Alluxio Enterprise Edition.\n\nDefault configuration requires 2 agent nodes each with: CPU: 3 | Memory: 5GB | Disk: 4GB\n\nMore specifically, each instance type requires:\n\nMaster: 1 instance | 2 CPU | 4096 MB MEM | 1 2048 MB Disk\n\nJob master: 1 instance | 1 CPU | 1024 MB MEM | 1 2048 MB Disk\n\nWorker: 1 instance | 2 CPU | 4096 MB MEM | 1 2048 MB Disk \n\nJob worker: 1 instance | 1 CPU | 1024 MB MEM | 1 2048 MB Disk \n\nVersion 2.0.0-1.6.0 contains breaking changes from previous releases. Upgrading from previous versions is not supported.",
-    "postInstallNotes": "DC/OS Alluxio is being installed!\n\n\tDocumentation: https://alluxio.com/docs/ \n\tIssues: info@aluxio.com",
-    "postUninstallNotes": "DC/OS Alluxio has been uninstalled."
-}
+  "packagingVersion": "4.0",
+  "upgradesFrom": [],
+  "downgradesTo": [],
+  "name": "alluxio-enterprise",
+  "version": "2.2.0-1.8.0",
+  "maintainer": "info@alluxio.com",
+  "description": "Alluxio, formerly Tachyon, is the world's first system that unifies disparate storage systems at memory speed. With Alluxio, enterprises can manage data efficiently, accelerate business analytics, and ease the adoption of hybrid cloud. \n\n Alluxio Enterprise Edition delivers operational benefits of a stable, high performance system with enterprise features and support for critical deployments. Please refer to https://alluxio.com/docs/enterprise/1.7/en/Alluxio-on-DCOS.html for a detailed operation guide. \n\n Release Notes: \n - Upgrade to version 1.7.1 of Alluxio \n - Support downloading multiple keytabs from Secret Store",
+  "selected": false,
+  "framework": true,
+  "tags": [
+    "enterprise",
+    "alluxio"
+  ],
+  "minDcosReleaseVersion": "1.10",
+  "preInstallNotes": "Visit https://alluxio.com/products to obtain a license for Alluxio Enterprise Edition.\n\nDefault configuration requires 2 agent nodes each with: CPU: 3 | Memory: 5GB | Disk: 4GB\n\nMore specifically, each instance type requires:\n\nMaster: 1 instance | 2 CPU | 4096 MB MEM | 1 2048 MB Disk\n\nJob master: 1 instance | 1 CPU | 1024 MB MEM | 1 2048 MB Disk\n\nWorker: 1 instance | 2 CPU | 4096 MB MEM | 1 2048 MB Disk \n\nJob worker: 1 instance | 1 CPU | 1024 MB MEM | 1 2048 MB Disk \n\nVersion 2.0.0-1.6.0 contains breaking changes from previous releases. Upgrading from previous versions is not supported.",
+  "postInstallNotes": "DC/OS Alluxio is being installed!\n\n\tDocumentation: https://alluxio.com/docs/enterprise/1.7/en/Alluxio-on-DCOS.html \n\tIssues: info@aluxio.com",
+  "postUninstallNotes": "DC/OS Alluxio has been uninstalled. \n\n Visit https://alluxio.com/docs/enterprise/1.7/en/Alluxio-on-DCOS.html to troubleshoot any issues."
+}--- 2/resource.json
+++ 100/resource.json
@@ -1,14 +1,16 @@
 {
   "assets": {
     "uris": {
-      "alluxio-agent": "https://alluxio-dcos-release.s3.amazonaws.com/agent",
-      "bootstrap-zip": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.0.0-1.6.0/bootstrap.zip",
-      "custom-download-url": "",
-      "executor-zip": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.0.0-1.6.0/executor.zip",
+      "alluxio-agent-darwin_386": "https://alluxio-dcos-release.s3.amazonaws.com/agent/v1.5.0/darwin_386/alluxio-dcos",
+      "alluxio-agent-darwin_amd64": "https://alluxio-dcos-release.s3.amazonaws.com/agent/v1.5.0/darwin_amd64/alluxio-dcos",
+      "alluxio-agent-linux_386": "https://alluxio-dcos-release.s3.amazonaws.com/agent/v1.5.0/linux_386/alluxio-dcos",
+      "alluxio-agent-linux_amd64": "https://alluxio-dcos-release.s3.amazonaws.com/agent/v1.5.0/linux_amd64/alluxio-dcos",
+      "bootstrap-zip": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.2.0-1.8.0/bootstrap.zip",
+      "executor-zip": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.2.0-1.8.0/executor.zip",
       "java-tar-gz": "https://alluxio-dcos-release.s3.amazonaws.com/jdk/jdk1.8.0_144_jce_policy.tar.gz",
-      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64-jce-unlimited.tar.gz",
-      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
-      "scheduler-zip": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.0.0-1.6.0/alluxio-enterprise-scheduler.zip"
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
+      "scheduler-zip": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.2.0-1.8.0/alluxio-enterprise-scheduler.zip"
     }
   },
   "images": {
@@ -23,11 +25,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "7b9f95b7dd8dc62638216ff0fc812a4ab1e9ac8462d0f7cfbe156cd0d7cdccce"
+              "value": "824feb0df24dcdc92ef18781b13da26190f87fd94533b51959dccf08311a0e0a"
             }
           ],
           "kind": "executable",
-          "url": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.0.0-1.6.0/dcos-service-cli-darwin"
+          "url": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.2.0-1.8.0/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -35,11 +37,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "b68c2636c7ac4b642b97f83c18773f10e5be65853562db3dc20ecfd621b2b562"
+              "value": "dd6d1a9b395dcb15239dad1de8d85c231a8624d0501402cc4c7d246b986f5387"
             }
           ],
           "kind": "executable",
-          "url": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.0.0-1.6.0/dcos-service-cli-linux"
+          "url": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.2.0-1.8.0/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -47,11 +49,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "46636da7a18a9b1c53c3c464f27fff5f0c8d86d0d7cb7cbefe8a9854f71cad18"
+              "value": "aec3e50813439b2478bf5bdb6a4dc54e6d2e9bdd607c59de82f9a11a5f4bd450"
             }
           ],
           "kind": "executable",
-          "url": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.0.0-1.6.0/dcos-service-cli.exe"
+          "url": "https://alluxio-dcos-release.s3.amazonaws.com/artifacts/2.2.0-1.8.0/dcos-service-cli.exe"
         }
       }
     }
```
